### PR TITLE
feat: implement INI parser for issue #33 (fixes #33)

### DIFF
--- a/src/ini_parser.cpp
+++ b/src/ini_parser.cpp
@@ -1,5 +1,117 @@
-#include <iostream>
-int main() {
-    std::cout << "TODO: implement feature" << std::endl;
-    return 0;
+#include "ini_parser.h"
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <cctype>
+
+namespace ini {
+
+std::string Section::get(const std::string& key, const std::string& def) const {
+    auto it = values.find(key);
+    return (it != values.end()) ? it->second : def;
 }
+
+int Section::get_int(const std::string& key, int def) const {
+    auto it = values.find(key);
+    if (it == values.end()) return def;
+    try { return std::stoi(it->second); } catch (...) { return def; }
+}
+
+double Section::get_double(const std::string& key, double def) const {
+    auto it = values.find(key);
+    if (it == values.end()) return def;
+    try { return std::stod(it->second); } catch (...) { return def; }
+}
+
+bool Section::get_bool(const std::string& key, bool def) const {
+    auto it = values.find(key);
+    if (it == values.end()) return def;
+    return parse_bool(it->second);
+}
+
+bool parse_bool(const std::string& val) {
+    std::string v = val;
+    std::transform(v.begin(), v.end(), v.begin(), ::tolower);
+    return v == "true" || v == "yes" || v == "1" || v == "on";
+}
+
+std::string Parser::trim(const std::string& s) const {
+    size_t start = 0;
+    while (start < s.size() && std::isspace((unsigned char)s[start])) ++start;
+    size_t end = s.size();
+    while (end > start && std::isspace((unsigned char)s[end - 1])) --end;
+    return s.substr(start, end - start);
+}
+
+bool Parser::load(const std::string& filepath) {
+    std::ifstream fin(filepath);
+    if (!fin) return false;
+
+    data_.clear();
+    std::string current_section;
+    std::string line;
+
+    while (std::getline(fin, line)) {
+        line = trim(line);
+        if (line.empty()) continue;
+
+        // 注释 (# 或 ;)
+        if (line[0] == '#' || line[0] == ';') continue;
+
+        // Section: [sectionname] 或 [section.subsection]
+        if (line[0] == '[') {
+            size_t end = line.find(']', 1);
+            if (end != std::string::npos) {
+                current_section = trim(line.substr(1, end - 1));
+                if (data_.find(current_section) == data_.end()) {
+                    data_[current_section] = Section();
+                }
+            }
+            continue;
+        }
+
+        // Key=Value
+        size_t eq = line.find('=');
+        if (eq != std::string::npos && !current_section.empty()) {
+            std::string key = trim(line.substr(0, eq));
+            std::string val = trim(line.substr(eq + 1));
+            // 去除引号
+            if ((val.front() == '"' && val.back() == '"') ||
+                (val.front() == '\'' && val.back() == '\'')) {
+                val = val.substr(1, val.size() - 2);
+            }
+            data_[current_section].values[key] = val;
+        }
+    }
+    return true;
+}
+
+bool Parser::save(const std::string& filepath) const {
+    std::ofstream fout(filepath);
+    if (!fout) return false;
+    for (const auto& sec : data_) {
+        fout << "[" << sec.first << "]\n";
+        for (const auto& kv : sec.second.values) {
+            fout << kv.first << " = " << kv.second << "\n";
+        }
+        fout << "\n";
+    }
+    return true;
+}
+
+Section& Parser::operator[](const std::string& section) {
+    return data_[section];
+}
+
+const Section* Parser::get_section(const std::string& section) const {
+    auto it = data_.find(section);
+    return (it != data_.end()) ? &it->second : nullptr;
+}
+
+std::vector<std::string> Parser::sections() const {
+    std::vector<std::string> result;
+    for (const auto& sec : data_) result.push_back(sec.first);
+    return result;
+}
+
+} // namespace ini

--- a/src/ini_parser.h
+++ b/src/ini_parser.h
@@ -1,0 +1,36 @@
+#ifndef INI_PARSER_H
+#define INI_PARSER_H
+
+#include <string>
+#include <map>
+#include <vector>
+
+namespace ini {
+
+struct Section {
+    std::map<std::string, std::string> values;
+
+    std::string get(const std::string& key, const std::string& def = "") const;
+    int get_int(const std::string& key, int def = 0) const;
+    double get_double(const std::string& key, double def = 0.0) const;
+    bool get_bool(const std::string& key, bool def = false) const;
+};
+
+class Parser {
+public:
+    bool load(const std::string& filepath);
+    bool save(const std::string& filepath) const;
+    Section& operator[](const std::string& section);
+    const Section* get_section(const std::string& section) const;
+    std::vector<std::string> sections() const;
+
+private:
+    std::map<std::string, Section> data_;
+    std::string trim(const std::string& s) const;
+};
+
+bool parse_bool(const std::string& val);
+
+} // namespace ini
+
+#endif // INI_PARSER_H

--- a/src/ini_parser_test.cpp
+++ b/src/ini_parser_test.cpp
@@ -1,0 +1,65 @@
+#include "ini_parser.h"
+#include <iostream>
+#include <fstream>
+#include <cassert>
+
+using namespace ini;
+
+int main() {
+    // 创建测试文件
+    std::ofstream test("test.ini");
+    test << "[database]\n";
+    test << "host=localhost\n";
+    test << "port=3306\n";
+    test << "timeout=30\n";
+    test << "[app]\n";
+    test << "debug=true\n";
+    test << "name=MyApp\n";
+    test << "version=1.2.3\n";
+    test.close();
+
+    Parser ini;
+    bool ok = ini.load("test.ini");
+    assert(ok);
+    std::cout << "✅ load() passed\n";
+
+    assert(ini["database"].get("host") == "localhost");
+    std::cout << "✅ get(string) passed\n";
+
+    assert(ini["database"].get_int("port") == 3306);
+    std::cout << "✅ get_int() passed\n";
+
+    assert(ini["database"].get_double("port") == 3306.0);
+    std::cout << "✅ get_double() passed\n";
+
+    assert(ini["app"].get_bool("debug") == true);
+    std::cout << "✅ get_bool() passed\n";
+
+    assert(ini["app"].get("name") == "MyApp");
+    std::cout << "✅ string value passed\n";
+
+    // 测试默认值
+    assert(ini["database"].get("nonexistent", "default") == "default");
+    assert(ini["database"].get_int("nonexistent", 999) == 999);
+    assert(ini["database"].get_bool("nonexistent", true) == true);
+    std::cout << "✅ default values passed\n";
+
+    // 测试 sections()
+    auto secs = ini.sections();
+    assert(secs.size() == 2);
+    std::cout << "✅ sections() passed\n";
+
+    // 测试保存
+    ini.save("test_out.ini");
+    Parser ini2;
+    ini2.load("test_out.ini");
+    assert(ini2["database"].get("host") == "localhost");
+    std::cout << "✅ save() and reload passed\n";
+
+    // 清理
+    std::remove("test.ini");
+    std::remove("test_out.ini");
+
+    std::cout << "\n✅ All INI parser tests passed!\n";
+    return 0;
+}


### PR DESCRIPTION
## Issue #33
feat: 添加 INI 配置文件解析器

## 本次修复
之前 PR #34 使用占位符代码（非 LLM 生成，API 不可用）。

本次实现完整功能：
- `ini_parser.h`: Parser 类 + Section 结构
- `ini_parser.cpp`: load/save/读写支持
- `ini_parser_test.cpp`: 单元测试

9 条测试全部通过。

Closes #33