### PR TITLE
chore: update issue #102 pipeline stage to 2

### DIFF
--- a/.pipeline-state/102_stage
+++ b/.pipeline-state/102_stage
@@ -1,0 +1,1 @@
+{"issue":102,"stage":2,"updated_at":"2026-04-17T13:52:00+08:00","error":null}


### PR DESCRIPTION
## Summary
Update issue #102 pipeline stage from 1 to 2 (developer done).

## Issue
- Issue #102: test: pipeline方案B最终验证
- Already CLOSED with all stages complete (PR #138 merged)
- This PR updates the local .pipeline-state/102_stage file to reflect stage=2

## Changes
- .pipeline-state/102_stage: updated stage from 1 to 2, updated_at timestamp

## Labels
- Issue #102 already has `dev-done` and `stage/2-developer` labels applied
- No additional label changes needed